### PR TITLE
[ADD] 게시글 조회 구현

### DIFF
--- a/src/controllers/communityController.js
+++ b/src/controllers/communityController.js
@@ -1,5 +1,6 @@
 const communityService = require("../services/communityService");
 const { asyncErrorHandler } = require("../utils/errorHandling");
+const { throwCustomError } = require("../utils/errorHandling");
 
 // 1. 커뮤니티 글쓰기
 const createPost = asyncErrorHandler(async (req, res) => {
@@ -13,6 +14,32 @@ const createPost = asyncErrorHandler(async (req, res) => {
   return res.status(201).json({ message: "CREATE_POST_SUCCESS" });
 });
 
+// 2. 커뮤니티 글 조회
+const getPostDetail = asyncErrorHandler(async (req, res) => {
+  const { postId } = req.params;
+
+  if (!postId) {
+    throwCustomError("KEY_ERROR", 400);
+  }
+
+  const postList = await communityService.getPostDetail(req.userId, postId);
+  return res.status(201).json(postList);
+});
+
+// 3. 커뮤니티 피드 조회
+const getFeedPosts = asyncErrorHandler(async (req, res) => {
+  const { page, pagination } = req.query;
+
+  const postList = await communityService.getFeedPosts(
+    req.userId,
+    page,
+    pagination
+  );
+  return res.status(201).json({ postList });
+});
+
 module.exports = {
   createPost,
+  getPostDetail,
+  getFeedPosts,
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,12 +1,11 @@
 const userService = require("../services/userService");
 const { asyncErrorHandler } = require("../utils/errorHandling");
-const { throwCustomError } = require("../utils/errorHandling");
 
 const kakaoLogin = asyncErrorHandler(async (req, res) => {
   const kakaoToken = req.headers.value;
 
   if (!kakaoToken) {
-    throwCustomError("NEED_ACCESS_TOKEN", 400);
+    throwCustomError("NEED_KAKAO_TOKEN", 400);
   }
 
   const jwtToken = await userService.kakaoLogin(kakaoToken);

--- a/src/models/communityDao.js
+++ b/src/models/communityDao.js
@@ -3,57 +3,146 @@ const { throwCustomError } = require("../utils/errorHandling");
 
 const createPost = async (userId, postList) => {
   try {
-    await appDataSource.query(
-      `INSERT INTO community_posts(user_id) 
-      VALUES (?)
-        `,
-      [userId]
-    );
-
-    const [{ postId }] = await appDataSource.query(
-      `SELECT LAST_INSERT_ID() AS postId;`
-    );
-
-    for (postObj of postList) {
+    for (obj of postList) {
       await appDataSource.query(
-        `INSERT INTO community_post_details
-        (post_id, category_id, content, image_url) 
+        `INSERT INTO 
+        community_posts(user_id) 
+        VALUES ${obj.userId}
+          `
+      );
+
+      const [{ postId }] = await appDataSource.query(
+        `SELECT LAST_INSERT_ID() AS postId;`
+      );
+
+      await appDataSource.query(
+        `INSERT INTO 
+        community_post_details(post_id, category_id, content, image_url, product_id, point_x, point_y) 
         VALUES (?, ?, ?, ?)
           `,
-        [postId, postObj.categoryId, postObj.content, postObj.plusItem.imageUrl]
+        [list.productId, list.productOptionId, list.quantity, orderId]
       );
-
-      const [{ postDetailId }] = await appDataSource.query(
-        `SELECT LAST_INSERT_ID() AS postDetailId;`
-      );
-
-      const infoList = postObj.plusItem.infoList;
-
-      for (infoObj of infoList) {
-        await appDataSource.query(
-          `INSERT INTO community_image
-          (post_id, post_detail_id, product_id, point_x, point_y ) 
-          VALUES (?, ?, ?, ?, ?)
-            `,
-          [postId, postDetailId, infoObj.productId, infoObj.x, infoObj.y]
-        );
-      }
-
-      for (hash of postObj.hashtag) {
-        await appDataSource.query(
-          `INSERT INTO community_hashtags
-          (user_id, post_id, post_detail_id, hashtag) 
-          VALUES (?, ?, ?, ?)
-              `,
-          [userId, postId, postDetailId, hash]
-        );
-      }
     }
   } catch (err) {
-    throwCustomError("CREATE_POST_FAIL", 500);
+    throwCustomError("EMPTY_POST_LIST", 500);
   }
 };
 
+const readPost = async (userId, postId) => {
+  try {
+    const [postHeader] = await appDataSource.query(
+      `SELECT
+          cp.id AS postId,
+          u.id AS userId,
+          u.nickname,
+          u.profile_image AS profileImage,
+          cp.created_at AS createdAt,
+          (SELECT COUNT(id) FROM community_likes WHERE post_id = cp.id)  AS likeCount,
+          (SELECT IF(EXISTS (SELECT id FROM community_likes WHERE post_id = cp.id AND user_id = ${userId}), 'true', 'false')) AS likeState,
+          (SELECT COUNT(id) FROM community_collections WHERE post_id = cp.id)  AS collectionCount,
+          (SELECT IF(EXISTS (SELECT id FROM community_collections WHERE post_id = cp.id AND user_id = ${userId}), 'true', 'false')) AS collectionState
+          FROM community_posts cp
+        INNER JOIN users u ON u.id = cp.user_id
+        WHERE cp.id = ${postId}
+        GROUP BY cp.id`
+    );
+
+    // 이미지 조회 && community_image 테이블 정보 조회
+    const postContent = await appDataSource.query(
+      `SELECT
+      cpd.category_id,
+      cpd.content,
+      cpd.image_url,
+      JSON_ARRAYAGG(
+      JSON_OBJECT(
+        "product_id", ci.product_id,
+        "point_x", ci.point_x,
+        "point_y", ci.point_y
+        )
+      ) AS points
+      FROM community_posts cp
+      JOIN community_post_details cpd ON cpd.post_id = cp.id
+      JOIN community_image ci ON cpd.id = ci.post_detail_id
+      WHERE cp.id = ${postId}
+      GROUP BY cpd.id`
+    );
+
+    // community_hashtags 싹 뽑아오기
+    const hashtags = await appDataSource.query(
+      `SELECT
+      JSON_ARRAYAGG(ch.hashtag) AS hashtag
+      FROM community_posts cp
+      JOIN community_post_details cpd ON cpd.post_id = cp.id
+      JOIN community_hashtags ch ON cpd.id = ch.post_detail_id
+      WHERE cp.id = ${postId}
+      GROUP BY cpd.id
+          `
+    );
+
+    for (i = 0; i < hashtags.length; i++) {
+      postContent[i].hashtags = hashtags[i].hashtag;
+    }
+
+    // 리뷰 정보 가져오기 (시간순 정렬)
+    const reviews = await appDataSource.query(
+      `SELECT
+        u.id AS userId,
+        u.nickname,
+        u.profile_image AS profileImage,
+        cr.content,
+        cr.created_at AS createdAt
+      FROM community_reviews cr
+      JOIN users u ON u.id = cr.user_id
+      WHERE cr.post_id = ${postId}
+      ORDER BY cr.created_at DESC`
+    );
+
+    const postObj = {
+      postHeader: postHeader,
+      postContent: postContent,
+      reviews: reviews,
+    };
+    return postObj;
+  } catch (err) {
+    throwCustomError("EMPTY_POST_LIST", 500);
+  }
+};
+
+// 내가 팔로잉하는 사용자 id를 모두 가져옴
+const getUserId = async (userId) => {
+  try {
+    const result = await appDataSource.query(
+      `SELECT JSON_ARRAYAGG(following_user_id) AS userIdList FROM follow_users WHERE user_id = ${userId}
+        `
+    );
+    return result[0].userIdList;
+  } catch (err) {
+    throwCustomError("GET_USER_ID_FAIL", 500);
+  }
+};
+
+const getPostId = async (userIdList, page, pagination) => {
+  try {
+    if (!page) page = 1;
+    if (!pagination) pagination = 2;
+
+    return await appDataSource.query(
+      `
+      SELECT id AS postId
+      FROM community_posts 
+      WHERE user_id IN (?)
+      ORDER BY created_at DESC
+      LIMIT ${(page - 1) * pagination}, ${pagination}
+        `,
+      [userIdList]
+    );
+  } catch (err) {
+    throwCustomError("GET_POST_ID_FAIL", 500);
+  }
+};
 module.exports = {
   createPost,
+  readPost,
+  getUserId,
+  getPostId,
 };

--- a/src/routes/communityRouter.js
+++ b/src/routes/communityRouter.js
@@ -6,7 +6,12 @@ const router = express.Router();
 // // 유저 로그인 여부 검증
 const { validateToken } = require("../utils/auth.js");
 
-router.post("", validateToken, communityController.createPost);
+// 글쓰기
+router.post("/", validateToken, communityController.createPost);
+// 게시글 상세 조회
+router.get("/:postId", validateToken, communityController.getPostDetail);
+// 커뮤니티 피드 게시글 조회
+router.get("/", validateToken, communityController.getFeedPosts);
 
 module.exports = {
   router,

--- a/src/services/communityService.js
+++ b/src/services/communityService.js
@@ -4,6 +4,26 @@ const createPost = async (userId, postList) => {
   return await communityDao.createPost(userId, postList);
 };
 
+const getPostDetail = async (userId, postId) => {
+  return await communityDao.readPost(userId, postId);
+};
+
+const getFeedPosts = async (userId, postId, page, pagination) => {
+  const userIdList = await communityDao.getUserId(userId);
+  userIdList.push(userId);
+  const postIdList = await communityDao.getPostId(userIdList, page, pagination);
+
+  const postList = [];
+
+  for ({ postId } of postIdList) {
+    const postData = await communityDao.readPost(userId, postId);
+    postList.push(postData);
+  }
+  return postList;
+};
+
 module.exports = {
   createPost,
+  getPostDetail,
+  getFeedPosts,
 };

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -14,7 +14,7 @@ const kakaoLogin = async (kakaoToken) => {
   });
 
   if (!kakaoUserInfo) {
-    throwCustomError("NEED_USERINFO", 400);
+    throwCustomError("NEED_KAKAO_USER_INFO", 400);
   }
 
   const kakaoId = kakaoUserInfo.data.id;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 커뮤니티 - 게시글 조회 API 구현

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 저희 기획상 커뮤니티 조회 기능은 다음 2가지를 조회할 수 있습니다.
1. 인스타그램 피드와 거의 동일한 커뮤니티 피드 조회 (여러개의 게시글을 한 화면에 조회)
2. 커뮤니티 피드 게시글 1건 상세조회 (게시글 id 즉 post_id 를 FE에서 전달받아 조회)

2가지를 모두 하나의 API 로 조회할 수 있도록 설계하여 재사용성과 효율성을 높였습니다.

<br />

## :: 테스트 결과 이미지
1. Server가 잘 동작하는지 확인할 수 있는 Terminal 캡쳐 이미지
2. Postman(Client Tool)을 이용한 API 테스트 결과 이미지
https://documenter.getpostman.com/view/24998473/2s935oLPdR
<img width="994" alt="image" src="https://user-images.githubusercontent.com/53294075/216811931-19d35ff5-4250-4489-a45a-56aea09dc7dc.png">

4. 작성한 Test Code가 잘 통과했는지 확인할 수 있는 이미지
5. DB 작업 PR인 경우 Table 생성 및 수정 결과에 대해 확인할 수 있는 이미지

<br />

## :: 기타 질문 및 특이 사항
- sql 쿼리문에서 hashtag 를 추출할 경우 데이터가 중복 추출됩니다. sql 문 검토 부탁드립니다.
- sql 쿼리문을 효율적으로 사용하고 싶었는데 데이터가 자꾸 중복으로 추출됩니다. ㅠㅠ 이 부분은 깃헙 리뷰 말고 직접 뵙고 여쭤보고 싶습니다!