### PR TITLE
[ADD] 커뮤니티 좋아요 / 스크랩 클릭 기능 API

### DIFF
--- a/src/controllers/communityController.js
+++ b/src/controllers/communityController.js
@@ -38,8 +38,32 @@ const getFeedPosts = asyncErrorHandler(async (req, res) => {
   return res.status(201).json({ postList });
 });
 
+// 4. 커뮤니티 게시글 - like 누르기
+const toggleLikeState = asyncErrorHandler(async (req, res) => {
+  const { postId } = req.params;
+
+  if (!postId) {
+    throwCustomError("KEY_ERROR", 400);
+  }
+  await communityService.toggleLikeState(req.userId, postId);
+  return res.status(201).json({ message: "TOGGLE_LIKE_SUCCESS" });
+});
+
+// 5. 커뮤니티 게시글 - 스크랩 누르기
+const toggleCollectionState = asyncErrorHandler(async (req, res) => {
+  const { postId } = req.params;
+
+  if (!postId) {
+    throwCustomError("KEY_ERROR", 400);
+  }
+  await communityService.toggleCollectionState(req.userId, postId);
+  return res.status(201).json({ message: "TOGGLE_COLLECTION_SUCCESS" });
+});
+
 module.exports = {
   createPost,
   getPostDetail,
   getFeedPosts,
+  toggleLikeState,
+  toggleCollectionState,
 };

--- a/src/models/communityDao.js
+++ b/src/models/communityDao.js
@@ -140,9 +140,59 @@ const getPostId = async (userIdList, page, pagination) => {
     throwCustomError("GET_POST_ID_FAIL", 500);
   }
 };
+
+const toggleLikeState = async (userId, postId) => {
+  try {
+    // DB 테이블에 기존에 좋아요 row 가 있는지 확인
+    const [{ likeState }] = await appDataSource.query(
+      `SELECT EXISTS (SELECT id FROM community_likes WHERE user_id = ${userId} AND post_id = ${postId}) AS likeState;
+        `
+    );
+
+    // 좋아요가 눌러져 있으면 DB에서 삭제
+    if (parseInt(likeState)) {
+      await appDataSource.query(
+        `DELETE from community_likes WHERE user_id = ${userId} AND post_id = ${postId}`
+      );
+    } // 좋아요가 없으면 새로 생성
+    else {
+      await appDataSource.query(
+        `INSERT INTO community_likes (user_id, post_id) VALUES (${userId}, ${postId})`
+      );
+    }
+  } catch (err) {
+    throwCustomError("LIKE_FAIL", 500);
+  }
+};
+
+const toggleCollectionState = async (userId, postId) => {
+  try {
+    // DB 테이블에 기존에 스크랩 row 가 있는지 확인
+    const [{ collectionState }] = await appDataSource.query(
+      `SELECT EXISTS (SELECT id FROM community_collections WHERE user_id = ${userId} AND post_id = ${postId}) AS collectionState;
+        `
+    );
+    // 스크랩이 눌러져 있으면 DB에서 삭제
+    if (parseInt(collectionState)) {
+      await appDataSource.query(
+        `DELETE from community_collections WHERE user_id = ${userId} AND post_id = ${postId}`
+      );
+    } // 스크랩이 없으면 새로 생성
+    else {
+      await appDataSource.query(
+        `INSERT INTO community_collections (user_id, post_id) VALUES (${userId}, ${postId})`
+      );
+    }
+  } catch (err) {
+    throwCustomError("COLLECTION_FAIL", 500);
+  }
+};
+
 module.exports = {
   createPost,
   readPost,
   getUserId,
   getPostId,
+  toggleLikeState,
+  toggleCollectionState,
 };

--- a/src/routes/communityRouter.js
+++ b/src/routes/communityRouter.js
@@ -12,6 +12,17 @@ router.post("/", validateToken, communityController.createPost);
 router.get("/:postId", validateToken, communityController.getPostDetail);
 // 커뮤니티 피드 게시글 조회
 router.get("/", validateToken, communityController.getFeedPosts);
+router.post("", validateToken, communityController.createPost);
+router.post(
+  "/like/:postId",
+  validateToken,
+  communityController.toggleLikeState
+);
+router.post(
+  "/collection/:postId",
+  validateToken,
+  communityController.toggleCollectionState
+);
 
 module.exports = {
   router,

--- a/src/services/communityService.js
+++ b/src/services/communityService.js
@@ -22,8 +22,18 @@ const getFeedPosts = async (userId, postId, page, pagination) => {
   return postList;
 };
 
+const toggleLikeState = async (userId, postId) => {
+  return await communityDao.toggleLikeState(userId, postId);
+};
+
+const toggleCollectionState = async (userId, postId) => {
+  return await communityDao.toggleCollectionState(userId, postId);
+};
+
 module.exports = {
   createPost,
   getPostDetail,
   getFeedPosts,
+  toggleLikeState,
+  toggleCollectionState,
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 커뮤니티 게시글 좋아요 / 스크랩 버튼 True/False 구현

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 좋아요/스크랩 버튼을 클릭할 때마다 DB 테이블에 row 추가/제거되도록 구현


<br />

## :: 테스트 결과 이미지
1. Server가 잘 동작하는지 확인할 수 있는 Terminal 캡쳐 이미지
2. Postman(Client Tool)을 이용한 API 테스트 결과 이미지
3. 작성한 Test Code가 잘 통과했는지 확인할 수 있는 이미지
4. DB 작업 PR인 경우 Table 생성 및 수정 결과에 대해 확인할 수 있는 이미지

<br />

## :: 기타 질문 및 특이 사항
- 산책로에도 똑같이 쓰이는 기능이라 리팩토링을 할 때 통합하면 좋을 것 같다고 생각했는데, 추후 확장성을 고려하면 좋아요와 스크랩의 기능은 분명 다르기 때문에 고민 끝에 커뮤니티 / 산책로 각각 좋아요 / 스크랩 기능을 만들었습니다.
- 어떻게 하면 효율적으로 설계하고 확장성을 높일지는.... 코딩할 때마다 고민입니다.
- 특히 이렇게 비슷한 기능이 쭉 나올 때는 더더욱요!
