### PR TITLE
[ADD] 산책로 좋아요/스크랩 API

### DIFF
--- a/src/controllers/promenadeController.js
+++ b/src/controllers/promenadeController.js
@@ -43,7 +43,31 @@ const getFeedPosts = asyncErrorHandler(async (req, res) => {
   return res.status(200).json({ postList });
 });
 
+// 3. 산책로 게시글 - like 누르기
+const toggleLikeState = asyncErrorHandler(async (req, res) => {
+  const { postId } = req.params;
+
+  if (!postId) {
+    throwCustomError("KEY_ERROR", 400);
+  }
+  await promenadeService.toggleLikeState(req.userId, postId);
+  return res.status(201).json({ message: "TOGGLE_LIKE_SUCCESS" });
+});
+
+// 4. 산책로 게시글 - 스크랩 누르기
+const toggleCollectionState = asyncErrorHandler(async (req, res) => {
+  const { postId } = req.params;
+
+  if (!postId) {
+    throwCustomError("KEY_ERROR", 400);
+  }
+  await promenadeService.toggleCollectionState(req.userId, postId);
+  return res.status(201).json({ message: "TOGGLE_COLLECTION_SUCCESS" });
+});
+
 module.exports = {
   getPostDetail,
   getFeedPosts,
+  toggleLikeState,
+  toggleCollectionState,
 };

--- a/src/routes/promenadeRouter.js
+++ b/src/routes/promenadeRouter.js
@@ -16,6 +16,18 @@ router.get("/:postId", validateToken, promenadeController.getPostDetail);
 // url/city=2&arrondissement=1&page=1&pagination=3
 router.get("/", validateToken, promenadeController.getFeedPosts);
 
+// 좋아요 / 스크랩
+router.post(
+  "/like/:postId",
+  validateToken,
+  promenadeController.toggleLikeState
+);
+router.post(
+  "/collection/:postId",
+  validateToken,
+  promenadeController.toggleCollectionState
+);
+
 module.exports = {
   router,
 };

--- a/src/services/promenadeService.js
+++ b/src/services/promenadeService.js
@@ -26,7 +26,17 @@ const getFeedPosts = async (userId, city, arrondissement, page, pagination) => {
   return postList;
 };
 
+const toggleLikeState = async (userId, postId) => {
+  return await promenadeDao.toggleLikeState(userId, postId);
+};
+
+const toggleCollectionState = async (userId, postId) => {
+  return await promenadeDao.toggleCollectionState(userId, postId);
+};
+
 module.exports = {
   getPostDetail,
   getFeedPosts,
+  toggleLikeState,
+  toggleCollectionState,
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 산책로 게시글 좋아요 / 스크랩 버튼 True/False 구현

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 좋아요/스크랩 버튼을 클릭할 때마다 DB 테이블에 row 추가/제거되도록 구현


<br />

## :: 테스트 결과 이미지
1. Server가 잘 동작하는지 확인할 수 있는 Terminal 캡쳐 이미지
2. Postman(Client Tool)을 이용한 API 테스트 결과 이미지
3. 작성한 Test Code가 잘 통과했는지 확인할 수 있는 이미지
4. DB 작업 PR인 경우 Table 생성 및 수정 결과에 대해 확인할 수 있는 이미지

<br />

## :: 기타 질문 및 특이 사항
- 커뮤니티에도 똑같이 쓰이는 기능을 단순 복붙하여 개발했더니 리팩토링의 필요성을 더욱 크게 느꼈습니다!
- 차라리 커뮤니티/산책로 라우터에 포함시키는 것이 아니라 likeRouter, CollectionRouter 를 따로 파는 게 나았을까요?
- 근데 라우터를 따로 팠어도 좋아요/스크랩 버튼만 누르는 건 원체 기능이 똑같아서... 차라리 인자 받아서 함수 한개로 처리하는게 나았을까요 ._.)
- 프론트에 전달되는 성공 메시지가 버튼 True/False 모두 toggle success 로 동일하다 보니 프론트에서 헷갈릴 수도 있겠다고 생각해요.
제 코드상 Dao 말고는 구별되는 메시지를 넣을 만한 부분이 없는데... 😂 아예 로직을 다르게 짜야 했던 걸까요?
